### PR TITLE
Not clearing the cache after install leads to non-working site

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Opigno is a Learning Management system built as a Drupal distribution.
 
 ## Post-install
 
-Run through the Opigno installer as normal.  You will not be asked for database credentials as those are already provided.
+Run through the Opigno installer as normal. You will not be asked for database credentials as those are already provided. After installation is complete, log into the environment and run `drush -y cache-rebuild` twice to clear the cache.
 
 ## Customizations
 


### PR DESCRIPTION
Default install results in "The website encountered an unexpected error. Please try again later."

Running `drush cr` twice as per https://www.drupal.org/project/drupal/issues/3161309 resolves this issue.